### PR TITLE
Capacity Intro Edits

### DIFF
--- a/docs-content/key-cap-scaling.html.md.erb
+++ b/docs-content/key-cap-scaling.html.md.erb
@@ -3,12 +3,11 @@ title: Key Capacity Scaling Indicators
 owner: PCF Metrics Platform Monitoring
 ---
 
-This topic describes key capacity scaling indicators that operators monitor to determine when
-they need to scale their Pivotal Cloud Foundry (PCF) deployments.
+This topic describes key capacity scaling indicators that operators may wish to monitor to determine when
+they need to scale their Pivotal Cloud Foundry (PCF) deployment.
 
 Pivotal provides these indicators to operators as general guidance for capacity scaling. 
-Each indicator is based on platform metrics from different components. 
-This guidance is applicable to most PCF v1.10 deployments.
+This guidance is applicable to most PCF v1.10 deployment.
 Pivotal recommends that operators fine-tune the suggested alert thresholds 
 by observing historical trends for their deployments. 
 

--- a/docs-content/key-cap-scaling.html.md.erb
+++ b/docs-content/key-cap-scaling.html.md.erb
@@ -3,7 +3,7 @@ title: Key Capacity Scaling Indicators
 owner: PCF Metrics Platform Monitoring
 ---
 
-This topic describes key capacity scaling indicators that operators may wish to monitor to determine when
+This topic describes key capacity scaling indicators that operators may want to monitor to determine when
 they need to scale their Pivotal Cloud Foundry (PCF) deployment.
 
 Pivotal provides these indicators to operators as general guidance for capacity scaling. 


### PR DESCRIPTION
Added "may wish" because it sounded to me too much like these are the only possible/valuable; rather they are the only ones we can actually provide at the moment. Dropped 's' off deployments, because they are per deployment and refer to it as deployment singular on KPI page. Removed the one sentence because copy should be reduced ideally and it wasn't that valuable of a sentence.