### PR TITLE
Updated cf-apps metric no data info

### DIFF
--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -14,7 +14,7 @@ owner: PCF Metrics Platform Monitoring
      }
 </style>
 
-<p class="note warning"><strong>INTERNAL NOTE</strong>: The following metrics still have some pieces of information confirmation outstanding and will likely need to be updated before final publication: Loggregator Dropped Messages (stated metric has issues, new in-progress metric info from team is needed), Router 502, 5XX (emission frequency to be confirmed, not matching testing output), CF-APPs (need final confirmation if 0 or no-data).</p>
+<p class="note warning"><strong>INTERNAL NOTE</strong>: The following metrics still have some pieces of information confirmation outstanding and will likely need to be updated before final publication: Loggregator Dropped Messages (stated metric has issues, new in-progress metric info from team is needed), Router 502, 5XX (emission frequency to be confirmed, not matching testing output).</p>
 
 This topic describes Key Performance Indicators (KPIs) that operators may want to monitor with their Pivotal Cloud Foundry (PCF) deployment to help ensure it is in a good operational state.
 
@@ -280,12 +280,12 @@ When observing extended periods of high or low activity trends, scale up or down
       <td>Indicates if the <code>cf-apps</code> Domain is up-to-date, meaning that CF App requests from Cloud Controller are synchronized to Diego desired AIs (<code>bbs.LRPsDesired</code>) for execution. 
             <ul>
               <li><code>1</code> means <code>cf-apps</code> Domain is up-to-date</li>
-              <li><code>0</code> means <code>cf-apps</code> Domain is not up-to-date</li>
+              <li><code>No data received</code> means <code>cf-apps</code> Domain is not up-to-date</li>
             </ul>
           <strong>Use</strong>: If the <code>cf-apps</code> Domain does not stay up-to-date, changes requested in the Cloud Controller are not guaranteed to propagate throughout the system. If the Cloud Controller and Diego are out of sync, then apps running could vary from those desired.
           <br><br>
           <strong>Origin</strong>: Doppler/Firehose<br>
-          <strong>Type</strong>: Gauge (Float 0 or 1)<br>
+          <strong>Type</strong>: Gauge (Float)<br>
           <strong>Frequency</strong>: 30 s<br>
    </tr>
    <tr>


### PR DESCRIPTION
Correction validated through final testing. It really is "no data" vs "0" when it is in unhealthy state.