### PR TITLE
Make it clearer bosh metrics are not default

### DIFF
--- a/docs-content/metrics.html.md.erb
+++ b/docs-content/metrics.html.md.erb
@@ -31,9 +31,11 @@ To set up PCF monitoring, you then configure PCF and your monitoring platform as
 
 You can configure PCF to direct metrics from all Elastic Runtime component VMs, including system components and hosts, to a monitoring platform. To do this, you configure component logs and metrics to stream from from the Loggregator [Firehose](../loggregator/architecture.html#firehose) endpoint and install a [nozzle](../loggregator/architecture.html#nozzles) that filters out the logs and directs the metrics to the monitoring platform.
 
-The Firehose logs and metrics come from two sources: 
+The Firehose metrics come from two sources: 
 
 * **BOSH Health Monitor**: The BOSH layer that underlies PCF generates `healthmonitor` metrics for all VMs in the deployment. 
+    * These metrics are not in the firehose by default. You must install the Open-Source [HM Forwarder](https://github.com/cloudfoundry/bosh-hm-forwarder) to send VM metrics through the firehose. 
+    * BOSH health metrics can also be retrieved outside the firehose using the [JMX Bridge](https://docs.pivotal.io/jmx-bridge/1-8/index.html).
 * **Cloud Foundry components**: Cloud Foundry component VMs for executive control, hosting, routing, traffic control, authentication, and other internal functions generate metrics.
 
 <p class="note"><b>Note</b>: PCF components specific to your IaaS also generate key metrics for health monitoring.</p>


### PR DESCRIPTION
Making this change because, as written, people will think they get bosh health metrics in firehose by default, that's not clear unless you keep reading a few paragraphs. This is something people already get confused on all the time. We can't get them into the firehose by default until PCF 1.12-1.13. I also eliminated the word "logs" in "logs and metrics" because we never talk about logs anywhere else on this page, and by saying "logs" you'd have to get into all the ways logs actually can/do get into the firehose for transmission as well as the log paths outside the firehose. Leaving it in could worsen confusion we already deal with that the firehose is not the only 'of interest to operators/devs' log transport mechanism in the platform.