### PR TITLE
Call out commercial products in overview statement

### DIFF
--- a/docs-content/metrics.html.md.erb
+++ b/docs-content/metrics.html.md.erb
@@ -15,7 +15,7 @@ Pivotal recommends that operators experiment with different combinations of metr
 
 ## <a id='overview'></a>Overview
 
-As a prerequisite to PCF monitoring, you need an account with a monitoring platform such as [Datadog](https://www.datadoghq.com/), [OpenTDSB](http://opentsdb.net/), [New Relic](https://newrelic.com/), [vRealize Operations (vROPS)](http://www.vmware.com/products/vrealize-operations.html), [AppDynamics](https://www.appdynamics.com) or another tool of choice.
+As a prerequisite to PCF monitoring, you need an account with a monitoring platform such as [Datadog](https://www.datadoghq.com/), [OpenTDSB](http://opentsdb.net/), [New Relic](https://newrelic.com/), [vRealize Operations (vROPS)](http://www.vmware.com/products/vrealize-operations.html), [AppDynamics](https://www.appdynamics.com), or another tool of choice.
 
 To set up PCF monitoring, you then configure PCF and your monitoring platform as follows:
 

--- a/docs-content/metrics.html.md.erb
+++ b/docs-content/metrics.html.md.erb
@@ -15,7 +15,7 @@ Pivotal recommends that operators experiment with different combinations of metr
 
 ## <a id='overview'></a>Overview
 
-As a prerequisite to PCF monitoring, you need an account with a monitoring platform such as [Datadog](https://www.datadoghq.com/) or [OpenTDSB](http://opentsdb.net/).
+As a prerequisite to PCF monitoring, you need an account with a monitoring platform such as [Datadog](https://www.datadoghq.com/), [OpenTDSB](http://opentsdb.net/), [New Relic](https://newrelic.com/), [vRealize Operations (vROPS)](http://www.vmware.com/products/vrealize-operations.html), [AppDynamics](https://www.appdynamics.com) or another tool of choice.
 
 To set up PCF monitoring, you then configure PCF and your monitoring platform as follows:
 


### PR DESCRIPTION
James Bayer made a good point that the commercial product mentions are low on the page, but Data Dog and OpenTSDB get a shout-out in the opening overview statement. Updating that overview statement to also include these examples are they resonate with enterprise customers more.