### PR TITLE
Update kpi.html.md.erb

### DIFF
--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -709,42 +709,6 @@ When observing extended periods of high or low activity trends, scale up or down
         </tr>
 </table>
 
-###<a id="ConsulDownMode"></a>Consul Up or Down
-<table>
-     <tr><th colspan="2" style="text-align: center;"><br>route_emitter.ConsulDownMode<br><br></th></tr>
-        <tr>
-                <th width="25%">Description</th>
-                <td>Consul emits its health status periodically. <code>0</code> means the system is healthy, and <code>1</code> means that 
-                    route emitter detects that Consul is down.
-                    <br><br>
-                    <strong>Use</strong>: During an upgrade, this can indicate that Consul is down.
-                    Loss of the Consul cluster results in apps becoming unavailable 
-                    because their routes were pruned from the routing table.
-                 <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
-                 <strong>Type</strong>: Gauge (Float, 0-1)<br>
-                 <strong>Frequency</strong>: Periodically, emission should be constant on a running, Diego-based, PCF deployment<br>
-        </tr>
-        <tr>
-                <th>Recommended measurement</th>
-                <td>Average over the last 5 minutes</td>
-        </tr>
-        <tr>
-                <th>Recommended alert thresholds</th>
-                <td><strong>Yellow warning</strong>: <em>N/A</em><br>
-                <strong>Red critical</strong>: Not equal to 0 </td>
-        </tr>
-        <tr>
-                <th>Recommended response</th>
-                <td>
-                    <ol>
-                        <li>During upgrade, reduce the Consul server nodes to 1 and then upgrade.</li>
-                        <li>Outside of an upgrade, consider disaster recovery for Consul.</li>
-                    </ol>
-                    </td>
-        </tr>
-</table>
-
 ## <a id="gorouter"></a> Gorouter Metrics
 
 ###<a id="total_requests"></a>Router Throughput

--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -666,41 +666,6 @@ When observing extended periods of high or low activity trends, scale up or down
         </tr>
 </table>
 
-
-## <a id="nsync_bulker"></a> Diego nsync_bulker Metrics
-
-###<a id="DesiredLRPSyncDuration"></a>Nsync-bulker Time to Sync
-<table>
-     <tr><th colspan="2" style="text-align: center;"><br>nsync_bulker.DesiredLRPSyncDuration<br><br></th></tr>
-        <tr>
-                <th width="25%">Description</th>
-                <td>Time in ns that the nsync-bulker took to synchronize CF apps and Diego DesiredLRPs.
-                    <br><br>
-                    <strong>Use</strong>: Cloud Controller and Diego brain should be kept synchronized. 
-                    This symptom can indicate that the BBS database is unhealthy. 
-                 <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
-                 <strong>Type</strong>: Gauge (Float in ns)<br>
-                 <strong>Frequency</strong>: 30 s<br>
-        </tr>
-        <tr>
-                <th>Recommended measurement</th>
-                <td>Maximum over the last 15 minutes 
-                    divided by 1,000,000,000</td>
-        </tr>
-        <tr>
-                <th>Recommended alert thresholds</th>
-                <td><strong>Yellow warning</strong>: &ge; 10 s<br>
-                <strong>Red critical</strong>: &ge; 20 s</td>
-        </tr>
-        <tr>
-                <th>Recommended response</th>
-                <td>
-                        Investigate BBS metrics and logs and Cloud Controller Bridge logs for errors.
-                    </td>
-        </tr>
-</table>
-
 ##<a id="route_emitter"></a>Diego router-emitter Metrics
 
 ###<a id="RouteEmitterSyncDuration"></a>Route Emitter Time to Sync


### PR DESCRIPTION
The nsync bulker is essentially gone, and so is this nsync_bulker recommendation now. Removing outright for 1.11 after convo with CC team (and Diego team)