### PR TITLE
Update key-cap-scaling.html.md.erb

### DIFF
--- a/docs-content/key-cap-scaling.html.md.erb
+++ b/docs-content/key-cap-scaling.html.md.erb
@@ -145,8 +145,7 @@ There is one key capacity scaling indicator recommended for Firehose performance
 
 <table>
   <tr>
-      <th colspan="2" style="text-align: center;">(DopplerServer.TruncatingBuffer.totalDroppedMessages + 
-          DopplerServer.doppler.shedEnvelopes) / DopplerServer.listeners.totalReceivedMessageCount</th>
+      <th colspan="2" style="text-align: center;">DopplerServer.doppler.shedEnvelopes / DopplerServer.listeners.totalReceivedMessageCount</th>
   </tr>
    <tr>
       <th width="25">Description</th>


### PR DESCRIPTION
Updating for 1.11 where the old metric, DopplerServer.TruncatingBuffer.totalDroppedMessages, is no longer a necessary part of the equation