### PR TITLE
Update key-cap-scaling.html.md.erb

### DIFF
--- a/docs-content/key-cap-scaling.html.md.erb
+++ b/docs-content/key-cap-scaling.html.md.erb
@@ -8,7 +8,7 @@ they need to scale their Pivotal Cloud Foundry (PCF) deployments.
 
 Pivotal provides these indicators to operators as general guidance for capacity scaling. 
 Each indicator is based on platform metrics from different components. 
-This guidance is applicable to most PCF v1.10 deployments.
+This guidance is applicable to most PCF v1.11 deployments.
 Pivotal recommends that operators fine-tune the suggested alert thresholds 
 by observing historical trends for their deployments. 
 
@@ -51,7 +51,7 @@ There are three key capacity scaling indicators recommended for Diego cell:
    </tr>
     <tr>
       <th>Additional details</th>
-      <td> <strong>Origin</strong>: Doppler/Firehose<br>
+      <td> <strong>Origin</strong>: Firehose<br>
            <strong>Type</strong>: Gauge (%)<br>
            <strong>Frequency</strong>: Emitted every 60 s<br>
            <strong>Applies to</strong>: cf:diego_cells
@@ -90,7 +90,7 @@ There are three key capacity scaling indicators recommended for Diego cell:
    </tr>
     <tr>
       <th>Additional details</th>
-      <td> <strong>Origin</strong>: Doppler/Firehose<br>
+      <td> <strong>Origin</strong>: Firehose<br>
            <strong>Type</strong>: Gauge (%)<br>
            <strong>Frequency</strong>: Emitted every 60 s<br>
            <strong>Applies to</strong>: cf:diego_cells
@@ -129,7 +129,7 @@ There are three key capacity scaling indicators recommended for Diego cell:
    </tr>
     <tr>
       <th>Additional details</th>
-      <td> <strong>Origin</strong>: Doppler/Firehose<br>
+      <td> <strong>Origin</strong>: Firehose<br>
            <strong>Type</strong>: Gauge (%)<br>
            <strong>Frequency</strong>: Emitted every 60 s<br>
            <strong>Applies to</strong>: cf:diego_cells
@@ -149,7 +149,7 @@ There is one key capacity scaling indicator recommended for Firehose performance
   </tr>
    <tr>
       <th width="25">Description</th>
-      <td> This derived value represents the firehose loss rate, or the total messages dropped as a percentage of the total message throughput
+      <td> This derived value represents the firehose loss rate, or the total messages dropped as a percentage of the total message throughput. Total messages include the combined stream of logs from all apps, and the metrics data from Cloud Foundry components.
        </td>
    </tr>
    <tr>
@@ -173,7 +173,7 @@ There is one key capacity scaling indicator recommended for Firehose performance
    </tr>
    <tr>
       <th>Additional details</th>
-      <td> <strong>Origin</strong>: Doppler/Firehose<br>
+      <td> <strong>Origin</strong>: Firehose<br>
            <strong>Type</strong>: Gauge (float)<br>
            <strong>Frequency</strong>: Base metrics are emitted every 5 s<br>
            <strong>Applies to</strong>: cf:doppler<br>
@@ -181,11 +181,98 @@ There is one key capacity scaling indicator recommended for Firehose performance
    </tr>
 </table>
 
-## <a id="scalable-syslog"></a> Scalable Syslog Scaling Indicator
-There is one key capacity scaling indicator recommended for the scalable syslog feature. 
+## <a id="scalable-syslog"></a> Scalable Syslog Performance Scaling Indicators
+There are three key capacity scaling indicators recommended for Scalable Syslog performance. 
 
-<p class="note"><strong>Note</strong>: This scalable syslog scaling indicator is only relevant
+<p class="note"><strong>Note</strong>: These scalable syslog scaling indicators are only relevant
   if your deployment contains apps using the scalable syslog drain binding feature (new in PCF v1.11).</p>
+
+### <a id="syslog-adapter-ksi"></a> Adapter Loss Rate
+
+<table>
+  <tr>
+      <th colspan="2" style="text-align: center;">scalablesyslog.adapter.dropped 
+                       / scalablesyslog.adapter.ingress</th>
+  </tr>
+   <tr>
+      <th width="25">Description</th>
+       <td>The loss rate of the scalable syslog adapters, that is, the total messages dropped as a percentage of the total traffic coming through the [scalable syslog adapters](../loggregator/architecture.html). Total messages include only logs for bound applications.
+       <br><br>
+			This loss rate is specific to the scalable syslog adapters and does not impact the Firehose loss rate.
+                        For example, you can suffer lossiness in syslog while not suffering any lossiness in the Firehose.
+      </td>
+   </tr>
+   <tr>
+      <th>Purpose</th>
+      <td>Indicates that the syslog drains are not keeping up with the number of logs 
+                            that a syslog-drain-bound app is producing.
+                            This likely means that the syslog-drain consumer is failing to keep up with the incoming log volume.         
+           <br><br>
+        The recommended scaling indicator is to look at the maximum per minute loss rate over a 5-minute window and scale if the derived loss rate value grows greater than <code>0.1</code>.
+   </tr>
+   <tr>
+      <th>Recommended thresholds</th>
+      <td><strong>Scale indicator</strong>: &ge; 0.1</br>
+      If alerting:<br>
+      <strong>Yellow warning</strong>: &ge; 0.01<br>
+      <strong>Red critical</strong>: &ge; 0.1</td>
+   </tr>
+   <tr>
+      <th>How to scale</th>
+      <td>Performance test your syslog server, reviewing the logs of the syslog consuming system for intake and other performance issues that may indicate a need to scale the consuming system.
+      </td>
+   </tr>
+   <tr>
+      <th>Additional details</th>
+      <td> <strong>Origin</strong>: Firehose<br>
+           <strong>Type</strong>: Counter (Integer)<br>
+           <strong>Frequency</strong>: Emitted every 60 s<br>
+           <strong>Applies to</strong>: cf:scalablesyslog<br>
+      </td>
+   </tr>
+</table>
+
+### <a id="syslog-rlp-ksi"></a> Reverse Log Proxy Loss Rate
+
+<table>
+  <tr>
+      <th colspan="2" style="text-align: center;">loggregator.rlp.dropped / loggregator.rlp.ingress</th>
+  </tr>
+   <tr>
+      <th width="25">Description</th>
+       <td>The loss rate of the reverse log proxies (RLP), that is, the total messages dropped as a percentage of the total traffic coming through the [reverse log proxy](../loggregator/architecture.html). Total messages include only logs for bound applications.
+       <br><br>
+			This loss rate is specific to the scalable syslog RLP and does not impact the Firehose loss rate.
+                        For example, you can suffer lossiness in syslog while not suffering any lossiness in the Firehose.
+      </td>
+   </tr>
+   <tr>
+      <th>Purpose</th>
+      <td>Excessive dropped messages can indicate that the RLP is overloaded and that the Traffic Controllers need to be scaled.
+         <br><br>
+        The recommended scaling indicator is to look at the maximum per minute loss rate over a 5-minute window and scale if the derived loss rate value grows greater than <code>0.1</code>.
+   </tr>
+   <tr>
+      <th>Recommended thresholds</th>
+      <td><strong>Scale indicator</strong>: &ge; 0.1</br>
+      If alerting:<br>
+      <strong>Yellow warning</strong>: &ge; 0.01<br>
+      <strong>Red critical</strong>: &ge; 0.1</td>
+   </tr>
+   <tr>
+      <th>How to scale</th>
+      <td>Scale up the number of traffic controller instances to further balance log load.
+      </td>
+   </tr>
+   <tr>
+      <th>Additional details</th>
+      <td> <strong>Origin</strong>: Firehose<br>
+           <strong>Type</strong>: Counter (Integer)<br>
+           <strong>Frequency</strong>: Emitted every 60 s<br>
+           <strong>Applies to</strong>: cf:scalablesyslog<br>
+      </td>
+   </tr>
+</table>
 
 ### <a id="scalable-syslog-ksi"></a> Scalable Syslog Drain Bindings Count
 
@@ -196,23 +283,22 @@ There is one key capacity scaling indicator recommended for the scalable syslog 
    <tr>
       <th width="25">Description</th>
        <td>The number of scalable syslog drain bindings.<br>
-           This metric was added in PCF v1.11.
        </td>
    </tr>
    <tr>
       <th>Purpose</th>
-      <td>Each scalable syslog adapter can handle approximately 500 drain bindings. 
+      <td>Each scalable syslog adapter can handle approximately 200 drain bindings. 
           The recommended initial configuration is a minimum of two scalable syslog adapters
-          (to handle approximately 1000 drain bindings). 
-          A new adapter instance should be added for each 500 additional drain bindings.
+          (to handle approximately 400 drain bindings). 
+          A new adapter instance should be added for each 200 additional drain bindings.
         <br><br>
-        Therefore, the recommended initial scaling indicator is 1500 (as a maximum value over a 1-hr window).
+        Therefore, the recommended initial scaling indicator is 550 (as a maximum value over a 1-hr window).
         This indicates the need to scale up to three adapters from the initial two-adapter configuration. 
          
    </tr>
    <tr>
       <th>Recommended thresholds</th>
-      <td><strong>Scale indicator</strong>: &ge; 1500<br>
+      <td><strong>Scale indicator</strong>: &ge; 550<br>
          Consider this threshold to be dynamic.
          Adjust the threshold to the PCF deployment as adoption of scalable syslog increases or decreases.</td>
    </tr>
@@ -223,14 +309,13 @@ There is one key capacity scaling indicator recommended for the scalable syslog 
    </tr>
    <tr>
       <th>Additional details</th>
-      <td> <strong>Origin</strong>: Doppler/Firehose<br>
+      <td> <strong>Origin</strong>: Firehose<br>
            <strong>Type</strong>: Gauge (float)<br>
            <strong>Frequency</strong>: Emitted every 60 s<br>
            <strong>Applies to</strong>: cf:scalablesyslog<br>
       </td>
    </tr>
 </table>
-
 
 ## <a id="Router"></a> Router Performance Scaling Indicator
 There is one key capacity scaling indicator recommended for Router performance. 


### PR DESCRIPTION
Updated - Should be final Loggregator changes for PCF 1.11
* Update inherited convention of “Doppler/Firehose” to “Firehose” on both KPI and KSI pages
* Needed to move Scalable Syslog Loss Rate from KPI to KSI, even though it’s about scaling the consuming system not PCF, it was too isolated away from the tightly related KSIs
* Adjusted Drain Bindings recommendations based on Loggregator continued testing. Loggregator will PR this doc to update again when the threshold is improved in a fix patch to 1.11(but should not hold up 1.11, this can go with lowered threshold now) 
* Added additional new Firehose Loss Rate metric related to scalable syslog 
* Added link to architecture diagram because these 2 exterior to the firehose, yet related to and emitting back into the firehose components are a little confusing with how it all fits together across the different Loss Rates 
* Added a clarifying note to Firehose Loss Rate to attempt to help distinguish more differences with other loss rates for loggregator