### PR TITLE
Update kpi.html.md.erb

### DIFF
--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -5,8 +5,8 @@ owner: PCF Metrics Platform Monitoring
 
 This topic describes Key Performance Indicators (KPIs) that operators may want to monitor with their Pivotal Cloud Foundry (PCF) deployment to help ensure it is in a good operational state.
 
-The following PCF v1.10 KPIs are provided for operators to give general guidance on monitoring a PCF deployment using platform component and system (BOSH) metrics. 
-Although many metrics are emitted from the platform, the following PCF v1.10 KPIs are 
+The following PCF v1.11 KPIs are provided for operators to give general guidance on monitoring a PCF deployment using platform component and system (BOSH) metrics. 
+Although many metrics are emitted from the platform, the following PCF v1.11 KPIs are 
 high-signal-value metrics that can indicate emerging platform issues. 
 
 This alerting and response guidance has been shown to apply to most deployments. 
@@ -30,7 +30,7 @@ metrics, thresholds, and alerts based on learning from their deployments.
       This error is most common due to capacity issues, for example, if cells do not have 
       enough resources or if cells are going back and forth between a healthy and unhealthy state.
       <br><br>
-      <strong>Origin</strong>: Doppler/Firehose<br>
+      <strong>Origin</strong>: Firehose<br>
       <strong>Type</strong>: Counter (Integer)<br>
       <strong>Frequency</strong>: During each auction<br>
    </tr>
@@ -71,7 +71,7 @@ metrics, thresholds, and alerts based on learning from their deployments.
       Alerting on this metric helps alert that app staging requests to Diego may be failing.
 
       <br><br>
-      <strong>Origin</strong>: Doppler/Firehose<br>
+      <strong>Origin</strong>: Firehose<br>
       <strong>Type</strong>: Gauge, integer in ns<br>
       <strong>Frequency</strong>: During event, during each auction<br>
    </tr>
@@ -108,7 +108,7 @@ metrics, thresholds, and alerts based on learning from their deployments.
                 The recommended measurement, below, can help indicate a significant amount of container churn. 
                 However, for capacity planning purposes, it is more helpful to observe deltas over a long time window. 
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Counter (Integer)<br>
                  <strong>Frequency</strong>: During event, during each auction<br>
         </tr>
@@ -149,7 +149,7 @@ When observing extended periods of high or low activity trends, scale up or down
                 <br><br>
 			This error is most common due to capacity issues, for example, if cells do not have enough resources or if cells are going back and forth between a healthy and unhealthy state. 
 			<br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Counter (Float)<br>
                  <strong>Frequency</strong>: During event, during each auction<br>
         </tr>
@@ -190,7 +190,7 @@ When observing extended periods of high or low activity trends, scale up or down
           apps or Tasks may be crashing without restarting. 
           This symptom can also indicate loss of connectivity to the BBS database.
           <br><br>
-          <strong>Origin</strong>: Doppler/Firehose<br>
+          <strong>Origin</strong>: Firehose<br>
           <strong>Type</strong>: Gauge (Integer in ns)<br>
           <strong>Frequency</strong>: During event,
                   every 30 seconds when LRP convergence runs, emission should be near-constant on a running deployment
@@ -229,7 +229,7 @@ When observing extended periods of high or low activity trends, scale up or down
           <strong>Use</strong>: If this metric rises, the PCF API is slowing. 
           Response to certain cf CLI commands is slow if request latency is high.
           <br><br>
-          <strong>Origin</strong>: Doppler/Firehose<br>
+          <strong>Origin</strong>: Firehose<br>
           <strong>Type</strong>: Gauge (Integer in ns)<br>
           <strong>Frequency</strong>: During event, when the BBS API handles requests, 
                   emission should be near-constant on a running deployment<br>
@@ -271,7 +271,7 @@ When observing extended periods of high or low activity trends, scale up or down
             </ul>
           <strong>Use</strong>: If the <code>cf-apps</code> Domain does not stay up-to-date, changes requested in the Cloud Controller are not guaranteed to propagate throughout the system. If the Cloud Controller and Diego are out of sync, then apps running could vary from those desired.
           <br><br>
-          <strong>Origin</strong>: Doppler/Firehose<br>
+          <strong>Origin</strong>: Firehose<br>
           <strong>Type</strong>: Gauge (Float)<br>
           <strong>Frequency</strong>: 30 s<br>
    </tr>
@@ -311,7 +311,7 @@ When observing extended periods of high or low activity trends, scale up or down
                         Deleting an app with many instances can temporarily spike this metric.  
                         However, a sustained spike in <code>bbs.LRPsExtra</code> is unusual and should be investigated.
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float)<br>
                  <strong>Frequency</strong>: 30 s<br>
         </tr>
@@ -347,7 +347,7 @@ When observing extended periods of high or low activity trends, scale up or down
                 <strong>Use</strong>: If Diego has less LRP running than expected, there may be problems with the BBS.<br><br> 
                         An app push with many instances can temporarily spike this metric. However, a sustained spike in <code>bbs.LRPsMissing</code> is unusual and should be investigated.
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float)<br>
                  <strong>Frequency</strong>: 30 s<br>
         </tr>
@@ -387,7 +387,7 @@ When observing extended periods of high or low activity trends, scale up or down
                 After you have a baseline, you can create a deployment-specific alert to notify of a spike in crashes above the trend line. 
                 Tune alert values to your deployment. 
                 <br><br>
-                <strong>Origin</strong>: Doppler/Firehose<br>
+                <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float)<br>
                  <strong>Frequency</strong>: 30 s<br>
         </tr>
@@ -427,7 +427,7 @@ When observing extended periods of high or low activity trends, scale up or down
                     Helps to provide a picture of the overall growth trend of the environment for capacity planning. 
                     You may want to alert on delta values outside of the expected range.
                     <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float)<br>
                  <strong>Frequency</strong>: During event, 
                          emission should be constant on a running deployment<br>
@@ -466,7 +466,7 @@ When observing extended periods of high or low activity trends, scale up or down
 	  <br><br>
 	      As an example, Pivotal Cloud Ops uses a standard of 4GB, and computes and monitors for the number of cells with at least 4GB free. When the number of cells with at least 4GB falls below a defined threshold, this is a scaling indicator alert to increase  capacity. This <em>free chunk</em> count threshold should be tuned to the deployment size and the standard size of apps being pushed to the deployment.<br><br>
 
-          <strong>Origin</strong>: Doppler/Firehose<br>
+          <strong>Origin</strong>: Firehose<br>
           <strong>Type</strong>: Gauge (Integer in bytes)<br>
           <strong>Frequency</strong>: 60 s<br>
    </tr>
@@ -517,7 +517,7 @@ When observing extended periods of high or low activity trends, scale up or down
           The overall sum of capacity can indicate that you need to scale the platform.
           Observing capacity consumption trends over time helps with capacity planning.
           <br><br>
-          <strong>Origin</strong>: Doppler/Firehose<br>
+          <strong>Origin</strong>: Firehose<br>
           <strong>Type</strong>: Gauge (Integer in bytes)<br>
           <strong>Frequency</strong>: 60 s<br>
    </tr>
@@ -554,7 +554,7 @@ When observing extended periods of high or low activity trends, scale up or down
 		<br><br>
 		It can also be meaningful to assess how many chunks of free disk space are above a given threshold, similar to <code>rep.CapacityRemainingMemory</code>.
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Integer in bytes)<br>
                  <strong>Frequency</strong>: 60 s<br>
         </tr>
@@ -588,7 +588,7 @@ When observing extended periods of high or low activity trends, scale up or down
                         <br><br>
                 <strong>Use</strong>: Sync times that are too high can indicate issues with the BBS.
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float in ns)<br>
                  <strong>Frequency</strong>: 30 s<br>
         </tr>
@@ -630,7 +630,7 @@ When observing extended periods of high or low activity trends, scale up or down
                  <br><br>
 		Suggested alert threshold based on multiple unhealthy cells in the given time window.
 		<br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float, 0-1)<br>
                  <strong>Frequency</strong>: 30 s<br>
         </tr>
@@ -670,7 +670,7 @@ When observing extended periods of high or low activity trends, scale up or down
                     The suggested starting point is &ge; 5 for the yellow threshold and &ge; 10 for the critical threshold. 
                     Pivotal has observed on its Pivotal Web Services deployment that above 10 s, the BBS may be failing.
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float in ns)<br>
                  <strong>Frequency</strong>: 60 s<br>
         </tr>
@@ -713,7 +713,7 @@ When observing extended periods of high or low activity trends, scale up or down
           This helps you see trends in the throughput rate that indicate a need to scale the Gorouter.
           Use the trends you observe to tune the threshold alerts for this metric. 
           <br><br>
-          <strong>Origin</strong>: Doppler/Firehose<br>
+          <strong>Origin</strong>: Firehose<br>
           <strong>Type</strong>: Counter (Integer)<br>
           <strong>Frequency</strong>: 5 s<br>
    </tr>
@@ -751,7 +751,7 @@ When observing extended periods of high or low activity trends, scale up or down
                     An alert value on this metric should be tuned to the specifics of the deployment and its underlying network considerations; 
                     a suggested starting point is 100 ms. 
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float in ms)<br>
                  <strong>Frequency</strong>: Emitted per Gorouter request,
                          emission should be constant on a running deployment
@@ -788,7 +788,7 @@ When observing extended periods of high or low activity trends, scale up or down
                         <br><br>
                 <strong>Use</strong>: Indicates if routes are not being registered to apps correctly. 
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float in ms)<br>
                  <strong>Frequency</strong>: 30 s<br>
         </tr>
@@ -832,7 +832,7 @@ When observing extended periods of high or low activity trends, scale up or down
                     which indicates that something has likely changed with the locations of the containers. 
                     Always investigate unexpected increases in this metric.
                     <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Count (Integer, Lifetime)<br>
                  <strong>Frequency</strong>: 5 s<br>
              </td>
@@ -871,7 +871,7 @@ When observing extended periods of high or low activity trends, scale up or down
                     However, response issues from apps can also cause an increase in 5xx responses.
                     Always investigate an unexpected increase in this metric.
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Counter (Integer)<br>
                  <strong>Frequency</strong>: 5 s<br>
         </tr>
@@ -914,7 +914,7 @@ When observing extended periods of high or low activity trends, scale up or down
 			<br><br>
 			If visualizing these metrics on a dashboard, <code>gorouter.total_routes</code> can be helpful by visualizing dramatic drops. However, for alerting purposes, the metric <code>gorouter.ms_since_last_registry_update</code> is more valuable for quicker identification of Gorouter issues. Alerting thresholds for <code>gorouter.total_routes</code> should focus on dramatic increases/decreases out of expected range.   
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Gauge (Float)<br>
                  <strong>Frequency</strong>: 30 s<br>
         </tr>
@@ -958,7 +958,7 @@ When observing extended periods of high or low activity trends, scale up or down
                     <br><br>
                     <strong>Use</strong>: Provides insight into how much traffic the logging system handles. This metric is an indicator of logging consistency.
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Counter (Integer)<br>
                  <strong>Frequency</strong>: 5 s<br>
         </tr>
@@ -995,7 +995,7 @@ When observing extended periods of high or low activity trends, scale up or down
                      or if the Firehose consumers are not keeping pace. 
                      Both issues result in dropped messages. 
                  <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
+                 <strong>Origin</strong>: Firehose<br>
                  <strong>Type</strong>: Counter (Integer)<br>
                  <strong>Frequency</strong>: 5 s<br>
         </tr>
@@ -1016,53 +1016,6 @@ When observing extended periods of high or low activity trends, scale up or down
                     </td>
         </tr>
 </table>
-
-## <a id="scalable-syslog"></a> Scalable Syslog Metrics
-
-<p class="note"><strong>Note</strong>: Scalable syslog metrics only apply 
-if your deployment contains apps that use the syslog-drain binding feature added in PCF v1.11.</p>
-
-###<a id="scalable-syslog-loss-rate"></a>Scalable Syslog Loss Rate
-<table>
-     <tr><th colspan="2" style="text-align: center;"><br>scalablesyslog.adapter.dropped 
-                       / scalablesyslog.adapter.ingress
-<br><br></th></tr>
-        <tr>
-                <th width="25%">Description</th>
-                <td>The loss rate of the scalable syslog adapters, that is, 
-                    the total messages dropped as a percentage of the total traffic coming through the scalable syslog adapters.
-                    <br><br>
-			This loss rate is specific to the scalable syslog adapters and does not impact the Firehose loss rate.
-                        For example, you can suffer lossiness in syslog while not suffering any lossiness in the Firehose.
-		    <br><br>
-                    <strong>Use</strong>: Indicates that the syslog drains are not keeping up with the number of logs 
-                            that a syslog-drain-bound app is producing.
-                            This likely means that the syslog-drain consumer is failing to keep up with the incoming log volume.
-                 <br><br>
-                 <strong>Origin</strong>: Doppler/Firehose<br>
-                 <strong>Type</strong>: Counter (Integer)<br>
-                 <strong>Frequency</strong>: 60 s<br>
-        </tr>
-        <tr>
-                <th>Recommended measurement</th>
-                <td>Maximum per minute loss rate
-                    over a 5-minute window</td>
-        </tr>
-        <tr>
-                <th>Recommended alert thresholds</th>
-                <td><strong>Yellow warning</strong>:&ge; 1%<br>
-                <strong>Red critical</strong>:&ge; 10%</td>
-        </tr>
-        <tr>
-                <th>Recommended response</th>
-                <td>
-        Performance test your syslog server,
-        reviewing the logs of the syslog consuming system for intake and other performance issues.                
-	</ol>
-                    </td>
-        </tr>
-</table>
-
 
 ## <a id="bosh"></a> System (BOSH) Metrics
 


### PR DESCRIPTION
Updated - Should be final Loggregator changes for PCF 1.11
* Update inherited convention of “Doppler/Firehose” to “Firehose” on both KPI and KSI pages
* Needed to move Scalable Syslog Loss Rate from KPI to KSI, even though it’s about scaling the consuming system not PCF, it was too isolated away from the tightly related KSIs