### PR TITLE
Update index.html.md.erb

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -27,16 +27,24 @@ This table highlights new and changed KPIs in PCF v1.11.
   </tr>
   <tr>
     <td><em>New</em></td>
-    <td>KPI: <strong><code>Scalable Syslog Loss Rate</code></strong><br><br>
-    A new component and new functionality within the Firehose system requires additional performance monitoring.
+    <td>KPI: <strong><code>Scalable Syslog Adapter Loss Rate</code></strong><br><br>
+    A new component and new functionality within the Loggregator system requires additional performance monitoring.
     The loss rate of the scalable syslog adapters is derived from two new metrics: <code>scalablesyslog.adapter.dropped</code> and 
     <code>scalablesyslog.adapter.ingress</code>.</td>
-    <td><a href="./kpi.html#scalable-syslog-loss-rate">Link</a></td>
+    <td><a href="./key-cap-scaling.html#syslog-adapter-ksi">Link</a></td>
+  </tr>
+    <tr>
+    <td><em>New</em></td>
+    <td>KPI: <strong><code>Scalable Syslog Reverse Log Proxy Loss Rate</code></strong><br><br>
+    A new component and new functionality within the Loggregator system requires additional performance monitoring.
+    The loss rate of the scalable syslog RLP is derived from two new metrics: <code>loggregator.rlp.dropped</code> and 
+    <code>loggregator.rlp.ingress</code>.</td>
+    <td><a href="./key-cap-scaling.html#syslog-rlp-ksi">Link</a></td>
   </tr>
   <tr>
     <td><em>New</em></td>
     <td>KPI: <strong><code>scalablesyslog.scheduler.drains</code></strong><br><br>
-    New component functionality within the Firehose system adds the need for additional performance monitoring considerations.</td>
+    New component functionality within the Loggregator system adds the need for additional performance monitoring considerations.</td>
     <td><a href="./key-cap-scaling.html#scalable-syslog-ksi">Link</a></td>
   </tr>
   <tr>


### PR DESCRIPTION
Updated - Should be final Loggregator changes for PCF 1.11
* Updated Scalable Syslog Rate link and name for changes made on other pages
* Added new KSI loss rate, also for syslog - Reverse Log Proxy Loss Rate
* Adam felt strongly about changing Firehose wording to Loggregator for any of the Syslog metric references; part of Loggregator, but not technically part of Firehose