### PR TITLE
Add Dynatrace monitoring

### DIFF
--- a/docs-content/metrics.html.md.erb
+++ b/docs-content/metrics.html.md.erb
@@ -15,7 +15,7 @@ Pivotal recommends that operators experiment with different combinations of metr
 
 ## <a id='overview'></a>Overview
 
-As a prerequisite to PCF monitoring, you need an account with a monitoring platform such as [SignalFx](https://signalfx.com/), [Datadog](https://www.datadoghq.com/), [OpenTDSB](http://opentsdb.net/), [New Relic](https://newrelic.com/), [vRealize Operations (vROPS)](http://www.vmware.com/products/vrealize-operations.html), [AppDynamics](https://www.appdynamics.com), or another tool.
+As a prerequisite to PCF monitoring, you need an account with a monitoring platform such as [SignalFx](https://signalfx.com/), [Datadog](https://www.datadoghq.com/), [OpenTDSB](http://opentsdb.net/), [New Relic](https://newrelic.com/), [vRealize Operations (vROPS)](http://www.vmware.com/products/vrealize-operations.html), [AppDynamics](https://www.appdynamics.com), [Dynatrace](https://www.dynatrace.com/), or another tool.
 
 To set up PCF monitoring, you then configure PCF and your monitoring platform as follows:
 
@@ -134,6 +134,7 @@ Some monitoring solutions offer both alerts and a dashboard in one package, whil
 
 Popular monitoring platforms among PCF customers include the following:
 
+* [Dynatrace](https://www.dynatrace.com/)
 * [Datadog](https://www.datadoghq.com/)
 * [OpenTSDB](http://opentsdb.net/) alerts and [Grafana](http://grafana.org/) dashboard
 * [New Relic](https://newrelic.com/)


### PR DESCRIPTION
This PR is is for adding Dynatrace to the monitoring section of your metrics descriptions.
The other PR (https://github.com/pivotal-cf/docs-monitoring/pull/47) is for PCF 1.10 docs.