### PR TITLE
Update kpi.html.md.erb

### DIFF
--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -523,12 +523,12 @@ When observing extended periods of high or low activity trends, scale up or down
    </tr>
    <tr>
       <th>Recommended measurement</th>
-      <td>5-minute sum across all cells divided by 0.000001024</td>
+      <td>Minimum over the last 5 minutes divided by 1024 (across all instances)</td>
   </tr>
   <tr>
       <th>Recommended alert thresholds</th>
-      <td><strong>Yellow warning</strong>: &le; 32<br>
-          <strong>Red critical</strong>: &le; 16</td>
+      <td><strong>Yellow warning</strong>: &le; 32 GB<br>
+          <strong>Red critical</strong>: &le; 16 GB</td>
    </tr>
    <tr>
       <th>Recommended response</th>
@@ -564,8 +564,8 @@ When observing extended periods of high or low activity trends, scale up or down
         </tr>
         <tr>
                 <th>Recommended alert thresholds</th>
-                <td><strong>Yellow warning</strong>: &le; 6<br>
-                <strong>Red critical</strong>:&le; 3.5 </td>
+                <td><strong>Yellow warning</strong>: &le; 6 GB<br>
+                <strong>Red critical</strong>:&le; 3.5 GB</td>
         </tr>
         <tr>
                 <th>Recommended response</th>


### PR DESCRIPTION
As written this is confusing a lot of people. Contextually it should work similarly to the Remaining Disk warning, which is not confusing people. The calculation stated was very specific to DD manipulation of how the data appears graphed. I’m updating this to better align with the less confusing Minimum Disk recommendation, which then makes more sense with the actual threshold values stated, and should be a clearer interpretation resulting in the intended purpose for the alert recommendation