### PR TITLE
Replace BOSH HM Forwarder with Firehose

### DIFF
--- a/docs-content/key-cap-scaling.html.md.erb
+++ b/docs-content/key-cap-scaling.html.md.erb
@@ -362,7 +362,7 @@ There is one key capacity scaling indicator recommended for Router performance.
    </tr>
    <tr>
       <th>Additional details</th>
-      <td> <strong>Origin</strong>: JMX Bridge or BOSH HM Forwarder<br>
+      <td> <strong>Origin</strong>: Firehose<br>
            <strong>Type</strong>: Gauge (float)<br>
            <strong>Frequency</strong>: Emitted every 60 s<br>
            <strong>Applies to</strong>: cf:router<br>
@@ -403,7 +403,7 @@ There is one key capacity scaling indicator for external S3 external storage.
    </tr>
     <tr>
       <th>Additional details</th>
-      <td> <strong>Origin</strong>: JMX Bridge or BOSH HM Forwarder<br>
+      <td> <strong>Origin</strong>: Firehose<br>
            <strong>Type</strong>: Gauge (%)<br>
            <strong>Applies to</strong>: cf:nfs_server<br>
       </td>


### PR DESCRIPTION
in PCF 2.0, Firehose is origin for these bosh metrics now