### PR TITLE
Fixing gorouter metric naming convention

### DIFF
--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -1271,7 +1271,7 @@ When PAS uses an internal MySQL database, as configured in the PAS tile **Settin
 ###<a id="route-registration"></a>Number of Route Registration Messages Sent and Received
 
 <table>
-     <tr><th colspan="2" style="text-align: center;"><br>gorouter.registry_message.route_emitter<br>route_emitter.MessagesEmitted<br><br></th></tr>
+     <tr><th colspan="2" style="text-align: center;"><br>gorouter.registry_message.route-emitter<br>route_emitter.MessagesEmitted<br><br></th></tr>
         <tr>
                 <th width="25%">Description</th>
                 <td>


### PR DESCRIPTION
This is coming out of PCF as a `-` not a `_`. More info on this needed correction can be seen here: https://pivotal.slack.com/archives/C6P0RC8UQ/p1512074593000241