### PR TITLE
Adding back UAA KPIs with edits post collaboration

### DIFF
--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -1321,6 +1321,107 @@ When PAS uses an internal MySQL database, as configured in the PAS tile **Settin
         </tr>
 </table>
 
+##<a id="uaa"></a>UAA Metrics
+
+###<a id="uaa_throughput"></a>UAA Throughput
+<table>
+  <tr><th colspan="2" style="text-align: center;"><br>uaa.requests.global.completed.count<br><br></th></tr>
+  <tr>
+    <th width="25%">Description</th>
+      <td>The lifetime number of requests completed by the UAA VM, emitted per UAA instance. Includes all requests sent to the server, including health checks. 
+        <br><br>
+        <strong>Use</strong>: For capacity planning purposes, the aggregation of these values across all UAA instances can provide insight into the overall load against UAA. It is recommended to alert on unexpected spikes per UAA instance. Unusually high spikes, if not known to be associated with an expected increase in demand, could indicate a DDoS risk, and should be investigated. For performance and capacity management, look at this metric as either a requests-completed-per-second or requests-completed-per-minute rate to understand the throughput per UAA instance. This helps you see trends in the throughput rate that may indicate a need to scale the UAA instances. Use the trends you observe to tune the threshold alerts for this metric. From performance and load testing of the UAA, Pivotal has observed that while different endpoints can have different throughput behavior, once throughput has reached a peak value per VM, throughput will begin to stay constant and latency will begin rising. 
+        <br><br>
+        <strong>Origin</strong>: Firehose<br>
+        <strong>Type</strong>: Gauge (Integer), emitted value increments over lifetime of VM like a counter<br>
+        <strong>Frequency</strong>: 5 s<br>
+      </td>
+    </tr>
+    <tr>
+      <th>Recommended measurement</th>
+      <td>Average over the last 5 minutes of the derived requests-per-second or requests-per-minute rate, per instance</td>
+    </tr>
+    <tr>
+      <th>Recommended alert thresholds</th>
+      <td><strong>Yellow warning</strong>: Dynamic<br>
+          <strong>Red critical</strong>: Dynamic</td>
+    </tr>
+    <tr>
+      <th>Recommended response</th>
+      <td>For optimizing the UAA, consider this metric in the context of UAA Request Latency and UAA VM CPU Utilization. To increase throughput and maintain low latency, scale the UAA VMs horizontally by editing the <b>UAA</b> VM in the <b>Resource Config</b> pane of the PAS tile, and watch that the system.cpu.user metric for the UAA is not sustained in the suggested range of 80-90% maximum CPU Utilization.
+      </td>
+    </tr>
+</table>
+
+###<a id="uaa_latency"></a>UAA Request Latency
+<table>
+  <tr><th colspan="2" style="text-align: center;"><br>gorouter.latency.uaa<br><br></th></tr>
+  <tr>
+    <th width="25%">Description</th>
+      <td>The time in milliseconds that the UAA took to process a request that GoRouter sent to UAA endpoints.
+        <br><br>
+        <strong>Use</strong>: Indicates how responsive UAA has been to requests sent from the Gorouter. Some operations may take longer amounts of time to process, such as bulk creating users and groups. It is important to correlate latency observed to the endpoint and evaluate latency in the context of overall historical latency performance from that endpoint. Unusual spikes in latency could indicate the need to scale the UAA VMs.
+        <br><br>
+        This metric is only emitted for the routers serving the UAA system component, and will not be emitted per isolation segment, even if leveraging isolated routers.
+        <br><br>
+        <strong>Origin</strong>: Firehose<br>
+        <strong>Type</strong>: Gauge (Float in ms)<br>
+        <strong>Frequency</strong>: Emitted per Gorouter request to UAA<br>
+      </td>
+    </tr>
+    <tr>
+      <th>Recommended measurement</th>
+      <td>Maximum, per job, over the last 5 minutes</td>
+    </tr>
+    <tr>
+      <th>Recommended alert thresholds</th>
+      <td><strong>Yellow warning</strong>: Dynamic<br>
+          <strong>Red critical</strong>: Dynamic</td>
+    </tr>
+    <tr>
+      <th>Recommended response</th>
+      <td>Latency is based upon the endpoint and operation being used. It is important to correlate the latency to the endpoint and evaluate latency in the context of the historical latency from that endpoint.
+	      <ol>
+            <li>First inspect which endpoints requests are hitting. Use historical value to understand if the latency is unusual for that endpoint. A list of UAA endpoints is available as part of the [UAA API documentation](http://docs.cloudfoundry.org/api/uaa/version/4.8.0/index.html).</li>
+            <li>If it appears that the UAA needs to scale due to ongoing traffic congestion, do not scale on the latency metric alone. You should also watch that the system.cpu.user metric for the UAA stays in the suggested range of 80-90% maximum CPU Utilization.</li>
+            <li>Resolve high utilization by scaling the UAA VMs horizontally by editing the <b>UAA</b> VM in the <b>Resource Config</b> pane of the PAS tile.</li>
+        </ol>
+      </td>
+    </tr>
+</table>
+
+###<a id="uaa_requests_inflight"></a>UAA Requests In Flight
+<table>
+  <tr><th colspan="2" style="text-align: center;"><br>uaa.server.inflight.count<br><br></th></tr>
+  <tr>
+    <th width="25%">Description</th>
+      <td>The number of requests the UAA is currently processing (in flight requests), emitted per UAA instance.
+        <br><br>
+        <strong>Use</strong>: Indicates how many concurrent requests are currently in flight for the UAA instance. Unusually high spikes, if not known to be associated with an expected increase in demand, could indicate a DDoS risk. 
+        <br><br>
+        From performance and load testing of the UAA component, Pivotal has observed that concurrent requests closely tie to increased throughput and latency. This helps you see trends in the Request Rate that may indicate the need to scale the UAA instances. Use the trends you observe to tune the threshold alerts for this metric. 
+        <br><br>
+        <strong>Origin</strong>: Firehose<br>
+        <strong>Type</strong>: Gauge (Integer)<br>
+        <strong>Frequency</strong>: 5 s<br>
+      </td>
+    </tr>
+    <tr>
+      <th>Recommended measurement</th>
+      <td>Maximum, per job, over the last 5 minutes</td>
+    </tr>
+    <tr>
+      <th>Recommended alert thresholds</th>
+      <td><strong>Yellow warning</strong>: Dynamic<br>
+          <strong>Red critical</strong>: Dynamic</td>
+    </tr>
+    <tr>
+      <th>Recommended response</th>
+      <td>To increase throughput and maintain low latency when in-flight requests are high, scale the UAA VMs horizontally by editing the <b>UAA</b> VM in the <b>Resource Config</b> pane of the PAS tile, and watch that the system.cpu.user metric for the UAA is not sustained in the suggested range of 80-90% maximum CPU Utilization.
+      </td>
+    </tr>
+</table>
+
 ## <a id="doppler-server"></a> Firehose Metrics
 
 ###<a id="listeners.receivedEnvelopes"></a>Firehose Throughput


### PR DESCRIPTION
UAA team and I worked together to finalize updates needed. I did make some additional minor text edits to better match the language of the other metrics, including how we talk about DDOS risk, etc. I'm putting the UAA group below Gorouter metrics because they are most contextually similar to these.