### PR TITLE
Update kpi.html.md.erb

### DIFF
--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -1339,7 +1339,7 @@ When PAS uses an internal MySQL database, as configured in the PAS tile **Settin
         From performance and load testing of UAA, Pivotal has observed that while UAA endpoints can have different throughput behavior, once throughput reaches its peak value per VM, it stays constant and latency increases.
         <br><br>
         <strong>Origin</strong>: Firehose<br>
-        <strong>Type</strong>: Counter (Integer)<br>
+        <strong>Type</strong>: Gauge (Integer), emitted value increments over the lifetime of the VM like a counter<br>
         <strong>Frequency</strong>: 5 s<br>
       </td>
     </tr>


### PR DESCRIPTION
Correcting back to match existing PCF 2.0 content. Because of how statsd injector works, even though UAA team updated this to be a counter in 2.1, it is still coming through the firehose emitted as a gauge.