### PR TITLE
Pulling Log Ingress Loss Rate content

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -22,13 +22,6 @@ This table highlights new and changed KPIs in PCF v2.1.
 <table>
   <tr>
     <td><em>Modified</em></td>
-    <td>KPI: <strong><code>uaa.requests.global.completed.count</code></strong><br><br>
-      The metric type has changed from <code>Gauge</code> to <code>Counter</code>.
-    </td>
-    <td><a href="./kpi.html#uaa_throughput">Link</a></td>
-  </tr> 
-  <tr>
-    <td><em>Modified</em></td>
     <td>KPI: <strong><code>rep.UnhealthyCell</code></strong><br><br>
     Added a recommended warning threshold of = 1 to prompt further investigation. Previously, only a critical threshold was recommended.
     </td>
@@ -44,7 +37,7 @@ This table highlights new and changed KPIs in PCF v2.1.
   <tr>
     <td><em>Modified</em></td>
     <td>KPI: <strong><code>Log Transport Loss Rate</code> (formerly Firehose Loss Rate)</strong><br><br>
-      In PCF v2.1, it is no longer necessary to include <code>DopplerServer.doppler.shedEnvelopes</code> or <code>DopplerServer.listeners.totalReceivedMessageCount</code> in the calculated values, as these metrics are now deprecated. The formula to calculate Loss Rate has been updated accordingly. Additionally, this measure of Loss Rate has been renamed to better distinguish it from the new Log Ingress Loss Rate scaling indicator. With the combination of <code>Log Ingress Loss Rate</code> and <code>Log Transport Loss Rate</code>, Operators are able to better determine where in the logs path loss is occurring, in order to better scale the right components.
+      In PCF v2.1, it is no longer necessary to include <code>DopplerServer.doppler.shedEnvelopes</code> or <code>DopplerServer.listeners.totalReceivedMessageCount</code> in the calculated values, as these metrics are now deprecated. The formula to calculate Loss Rate has been updated accordingly. Additionally, this measure of Loss Rate has been renamed to better distinguish it from future measures regarding Log Ingress.
       <br><br>
       Due to improvements in the underlying architecture, recommended thresholds are now:
          <ul>
@@ -52,14 +45,7 @@ This table highlights new and changed KPIs in PCF v2.1.
          <li>Critical/Red &ge; 0.001</li>
          </ul>
     </td>
-    <td><a href="./key-cap-scaling.html#firehose-ingress-loss-rate">Link</a></td>
-  </tr> 
-  <tr>
-    <td><em>New</em></td>
-    <td>KPI: <strong><code>Log Ingress Loss Rate</code></strong><br><br>
-      New metrics allow for measurement of loss at the Metron and Doppler component level. When combined with the <code>Log Transport Loss Rate</code> indicator, Operators are able to better determine where in the logs path loss is occurring, in order to better scale the right components.
-    </td>
-    <td><a href="./key-cap-scaling.html#firehose-ingress-loss-rate">Link</a></td>
+    <td><a href="./key-cap-scaling.html#firehose-loss-rate">Link</a></td>
   </tr> 
   <tr>
     <td><em>New</em></td>
@@ -71,14 +57,14 @@ This table highlights new and changed KPIs in PCF v2.1.
   <tr>
     <td><em>Deleted</em></td>
     <td>KPI: <strong><code>Firehose Dropped Messages</code></strong><br><br>
-      With the addition of new Firehose metrics, this metric is no longer recommended as a high-value monitoring indicator. <a href="key-cap-scaling.html#firehose-ingress-loss-rate">Log Ingress Loss Rate</a> and <a href="key-cap-scaling.html#firehose-loss-rate">Log Transport Loss Rate</a> are now the recommended indicators for scaling needs.
+      With the addition of new Firehose metrics, this metric is no longer recommended as a high-value monitoring indicator. 
     </td>
     <td><em>n/a</em></td>
   </tr> 
   <tr>
     <td><em>Deleted</em></td>
     <td>KPI: <strong><code>Firehose Throughput</code></strong><br><br>
-      With the addition of new Firehose metrics, this metric is no longer recommended as a high-value monitoring indicator. <a href="key-cap-scaling.html#doppler-message-rate-ksi">Doppler Message Rate Capacity</a> is now the recommended indicator for scaling needs.
+      With the addition of new Firehose metrics, this metric is no longer recommended as a high-value monitoring indicator. <a href="key-cap-scaling.html#firehose-loss-rate">Log Transport Loss Rate</a> and <a href="key-cap-scaling.html#doppler-message-rate-ksi">Doppler Message Rate Capacity</a> are the recommended indicators for scaling needs.
     </td>
     <td><em>n/a</em></td>
   </tr> 


### PR DESCRIPTION
We have to pull the new Log Ingress Loss Rate recommendation from PCF 2.1 content. There are some underlying issues to resolve still. Once those are resolved the recommendation will likely be made for PCF 2.2.