### PR TITLE
Add known issue to metric for v2.1

### DIFF
--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -1372,6 +1372,8 @@ When PAS uses an internal MySQL database, as configured in the PAS tile **Settin
         <br><br>
         This metric is emitted only for the routers serving the UAA system component and is not emitted per isolation segment even if you are using isolated routers.
         <br><br>
+	**Known Issue**: This metric is not currently being emitted in PCF v2.1.
+	<br><br>
         <strong>Origin</strong>: Firehose<br>
         <strong>Type</strong>: Gauge (Float in ms)<br>
         <strong>Frequency</strong>: Emitted per Gorouter request to UAA<br>


### PR DESCRIPTION
PCF v2.1 is not currently emitting this metric (cf is). Background https://pivotal.slack.com/archives/C0555LE4W/p1520965583000803. Being resolved in https://www.pivotaltracker.com/story/show/155958008. Best approach is to add a known issue in the meantime, and then update it with the given PAS version fix when this is finished being backpatched.