### PR TITLE
Healthwatch metrics cross-link (working w Paul S)

### DIFF
--- a/docs-content/key-cap-scaling.html.md.erb
+++ b/docs-content/key-cap-scaling.html.md.erb
@@ -57,6 +57,12 @@ There are three key capacity scaling indicators recommended for Diego cell:
            <strong>Applies to</strong>: cf:diego_cells
       </td>
    </tr>
+    <tr>
+      <th>Alternative Metric</th>
+      <td>      
+      If leveraging [PCF Healthwatch](https://network.pivotal.io/products/p-healthwatch), the derived metric [healthwatch.Diego.TotalPercentageAvailableMemoryCapacity.5M](http://docs.pivotal.io/pcf-healthwatch/1-1/metrics.html#memory) is recommended for this purpose. 
+      </td>
+   </tr>
 </table>
 
 ###<a id="cell-disk"></a>Diego Cell Disk Capacity
@@ -96,6 +102,12 @@ There are three key capacity scaling indicators recommended for Diego cell:
            <strong>Applies to</strong>: cf:diego_cells
       </td>
    </tr>
+    <tr>
+      <th>Alternative Metric</th>
+      <td>      
+      If leveraging [PCF Healthwatch](https://network.pivotal.io/products/p-healthwatch), the derived metric [healthwatch.Diego.TotalPercentageAvailableDiskCapacity.5M](http://docs.pivotal.io/pcf-healthwatch/1-1/metrics.html#disk) is recommended for this purpose. 
+      </td>
+   </tr>
 </table>
 
 ###<a id="cell-container"></a>Diego Cell Container Capacity
@@ -133,6 +145,12 @@ There are three key capacity scaling indicators recommended for Diego cell:
            <strong>Type</strong>: Gauge (%)<br>
            <strong>Frequency</strong>: Emitted every 60 s<br>
            <strong>Applies to</strong>: cf:diego_cells
+      </td>
+   </tr>
+    <tr>
+      <th>Alternative Metric</th>
+      <td>      
+      If leveraging [PCF Healthwatch](https://network.pivotal.io/products/p-healthwatch), the derived metric [healthwatch.Diego.TotalPercentageAvailableContainerCapacity.5M](http://docs.pivotal.io/pcf-healthwatch/1-1/metrics.html#cell-container) is recommended for this purpose. 
       </td>
    </tr>
 </table>
@@ -178,6 +196,12 @@ There is one key capacity scaling indicator recommended for Firehose performance
            <strong>Type</strong>: Gauge (float)<br>
            <strong>Frequency</strong>: Base metrics are emitted every 5 s<br>
            <strong>Applies to</strong>: cf:doppler<br>
+      </td>
+   </tr>
+    <tr>
+      <th>Alternative Metric</th>
+      <td>      
+      If leveraging [PCF Healthwatch](https://network.pivotal.io/products/p-healthwatch), the derived metric <code>healthwatch.Firehose.LossRate.1H</code> or [healthwatch.Firehose.LossRate.1M](http://docs.pivotal.io/pcf-healthwatch/1-1/metrics.html#firehose-loss) is recommended for this purpose. 
       </td>
    </tr>
 </table>
@@ -234,6 +258,12 @@ There are three key capacity scaling indicators recommended for CF Syslog Drain 
            <strong>Applies to</strong>: cf:cf-syslog<br>
       </td>
    </tr>
+    <tr>
+      <th>Alternative Metric</th>
+      <td>      
+      If leveraging [PCF Healthwatch](https://network.pivotal.io/products/p-healthwatch), the derived metric [healthwatch.SyslogDrain.Adapter.LossRate.1M](http://docs.pivotal.io/pcf-healthwatch/1-1/metrics.html#adapter-loss) is recommended for this purpose. 
+      </td>
+   </tr>
 </table>
 
 ### <a id="syslog-rlp-ksi"></a> Reverse Log Proxy Loss Rate
@@ -279,6 +309,12 @@ There are three key capacity scaling indicators recommended for CF Syslog Drain 
            <strong>Applies to:</strong> cf:cf-syslog<br>
       </td>
    </tr>
+    <tr>
+      <th>Alternative Metric</th>
+      <td>      
+      If leveraging [PCF Healthwatch](https://network.pivotal.io/products/p-healthwatch), the derived metric [healthwatch.SyslogDrain.RLP.LossRate.1M](http://docs.pivotal.io/pcf-healthwatch/1-1/metrics.html#rlp-loss) is recommended for this purpose. 
+      </td>
+   </tr>
 </table>
 
 ### <a id="scalable-syslog-ksi"></a> CF Syslog Drain Bindings Count
@@ -322,6 +358,13 @@ There are three key capacity scaling indicators recommended for CF Syslog Drain 
            <strong>Applies to"</strong> cf:cf-syslog<br>
       </td>
    </tr>
+    <tr>
+      <th>Alternative Metric</th>
+      <td>      
+      If leveraging [PCF Healthwatch](https://network.pivotal.io/products/p-healthwatch), the derived metric [healthwatch.SyslogDrain.Adapter.BindingsAverage.5M](http://docs.pivotal.io/pcf-healthwatch/1-1/metrics.html#syslog-drain-binding-capacity) is recommended for this purpose. 
+      </td>
+   </tr>
+
 </table>
 
 ## <a id="Router"></a> Router Performance Scaling Indicator


### PR DESCRIPTION
This PR should not be merged until @pspinrad takes a look at it. He and I met recently about how to best add links back to relevant Healthwatch super-metrics from the source KPI recommendations. It was helpful for me to PR these to show what maps to what, but I expect Paul may still want to do some massaging on wording/appearance/placement. This will be 1 of 4 PRs related to this work.