### PR TITLE
KSI correction backport to 2.1

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -48,6 +48,13 @@ This table highlights new and changed KPIs in PCF v2.1.
     <td><a href="./key-cap-scaling.html#firehose-loss-rate">Link</a></td>
   </tr> 
   <tr>
+  <td><em>Modified</em></td>
+  <td>KPI: <strong><code>Scalable Syslog Drain Bindings Count</code></strong><br><br>
+    As of May 2018, the recommended scaling threshold for this metric was modified downward.
+  </td>
+  <td><a href="./key-cap-scaling.html#scalable-syslog-ksi">Link</a></td>
+</tr>
+  <tr>
     <td><em>New</em></td>
     <td>KPI: <strong><code>Doppler Message Rate Capacity</code></strong><br><br>
       Indicates the need to scale based on the recommended maximum load for Doppler instances.


### PR DESCRIPTION
Loggregator KSI necessary change will be back-ported to 1.12 via other PRs due to reassessment of the recommendation post issues