### PR TITLE
KSI correction backport to 2.0

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -31,6 +31,8 @@ This table highlights new and changed KPIs in PCF v2.0.
     <td><em>Modified</em></td>
     <td>KPI: <strong><code>Syslog Drain Bindings Count</code></strong><br><br>
       The origin name of this metric has changed from <code>scalablesyslog</code> to <code>cf-syslog-drain</code>.
+        <br><br>
+      As of May 2018, the recommended scaling threshold for this metric was modified downward.
     </td>
     <td><a href="./key-cap-scaling.html#scalable-syslog-ksi">Link</a></td>
   </tr>    


### PR DESCRIPTION
Loggregator KSI necessary change will be back-ported to 1.12 via other PRs due to reassessment of the recommendation post issues