### PR TITLE
KSI correction backport to 1.12

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -74,6 +74,8 @@ The internal MySQL job included in Elastic Runtime now emits metrics. See the [E
     <td><em>Modified</em></td>
     <td>KPI: <strong><code>Scalable Syslog Drain Bindings Count</code></strong><br><br>
       Due to improvements in the underlying Adapter memory utilization, the number of adapters handled per drain has increased. This allows the recommended threshold scaling indicator to be increased accordingly. 
+      <br><br>
+      As of May 2018, the recommended scaling threshold for this metric was modified downward.
     </td>
     <td><a href="./key-cap-scaling.html#scalable-syslog-ksi">Link</a></td>
   </tr>


### PR DESCRIPTION
Loggregator KSI necessary change will be back-ported to 1.12 via other PRs due to reassessment of the recommendation post issues