### PR TITLE
Update index.html.md.erb

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -23,7 +23,8 @@ This table highlights new and changed KPIs in PCF v2.4.
   <tr>
     <td><em>Modified</em></td>
     <td>KPI: <strong><code>locket.ActiveLocks</code></strong><br><br>
-      The Clock Global (Cloud Controller clock) job now also holds a component lock. Therefore the expected number of Active Locks increased to 5.
+      The Clock Global (Cloud Controller clock) job now also holds a component lock. Therefore the expected number of Active Locks increased to 5. If the Operator disables Zero Downtime App Deployments when configuring PAS, then the expected value will remain 4 for PAS v2.4.
+      
     </td>
     <td><a href="./kpi.html#ActiveLocks">Link</a></td>
   </tr> 


### PR DESCRIPTION
Adding note about option setting only in 2.4 that, when checked, will keep the active lock value at 4 instead of the new expected value of 5.