### PR TITLE
Documentation about log-cache cache period.

### DIFF
--- a/docs-content/key-cap-scaling.html.md.erb
+++ b/docs-content/key-cap-scaling.html.md.erb
@@ -483,6 +483,45 @@ There are three key capacity scaling indicators recommended for CF Syslog Drain 
 </tr>
 </table>
 
+## <a id="log-cache"></a> Log Cache Scaling Indicator
+
+Pivotal recommends the following scaling indicator for monitoring the performance of Log Cache.
+
+### <a id="cache-duration"></a> Log Cache caching duration
+
+<table>
+  <tr>
+      <th colspan="2" style="text-align: center;">log_cache.cache_period</th>
+  </tr>
+   <tr>
+      <th width="25">Description</th>
+      <td>This metric indicates age of the oldest datapoint stored in the cache in milliseconds.</td>
+   </tr>
+   <tr>
+      <th>Purpose</th>
+      <td>Log Cache stores all messages that are passed through the firehose in an ephemeral in-memory store. The size of this store and therefore the cache duration are dependend on the amount of memory available on the VM. Some features of PAS rely on data being available in Log Cache, like the PAS Autoscaller. 
+         <br><br>
+        It is recommended to size the VM on which Log Cache runs (typically Doppler), so that Log Cache can hold at least the all messages that passed throughh loggregaotr in the last 15 minutes (900000 ms).
+   </tr>
+   <tr>
+      <th>Recommended thresholds</th>
+      <td><strong>Scale indicator</strong>: Scale when the cache period drops below 15 minutes (900000ms) <br>
+   </tr>
+   <tr>
+      <th>How to scale</th>
+      <td>Scale up the number of Doppler VMs or chose a VM-type for Doppler that provides more memory. 
+      </td>
+   </tr>
+   <tr>
+      <th>Additional details</th>
+      <td> <strong>Origin</strong>: log-cache<br>
+           <strong>Type</strong>: Gauge<br>
+           <strong>Frequency</strong>: Emitted every 15&nbsp;s<br>
+           <strong>Applies to</strong>: cf:log-cache<br>
+      </td>
+   </tr>
+</table>
+
 ## <a id="Router"></a> Router Performance Scaling Indicator
 There is one key capacity scaling indicator recommended for Router performance. 
 


### PR DESCRIPTION
In PAS 2.5 the log-cache metrics will flow through loggregator and can therefore be monitored in HW. Cache Duration/Period is the first metrics we should care about and document.


Relevant stories:
https://www.pivotaltracker.com/story/show/164380660
https://www.pivotaltracker.com/n/projects/1610633/stories/157848862