### PR TITLE
Update key-cap-scaling.html.md.erb

### DIFF
--- a/docs-content/key-cap-scaling.html.md.erb
+++ b/docs-content/key-cap-scaling.html.md.erb
@@ -234,7 +234,7 @@ There are two key capacity scaling indicators recommended for Firehose performan
       <th>Additional details</th>
       <td> <strong>Origin</strong>: Firehose<br>
            <strong>Type</strong>: Gauge (float)<br>
-           <strong>Frequency</strong>: Emitted every 15 s<br>
+           <strong>Frequency</strong>: Emitted every 5 s<br>
            <strong>Applies to</strong>: cf:doppler<br>
       </td>
    </tr>


### PR DESCRIPTION
Fix `loggregator.doppler.ingress` frequency value. This is incorrect in 2.3+ and has always been 5s.

[#167056840](https://www.pivotaltracker.com/story/show/167056840)