### PR TITLE
remove Route Registration Messages Delta from KPI docs

### DIFF
--- a/docs-content/kpi.html.md.erb
+++ b/docs-content/kpi.html.md.erb
@@ -1378,60 +1378,6 @@ When PAS uses an internal MySQL database, as configured in the PAS tile **Settin
         </tr>
 </table>
 
-### <a id="route-registration"></a> Number of Route Registration Messages Sent and Received
-
-<table>
-     <tr><th colspan="2" style="text-align: center;"><br>gorouter.registry_message.route-emitter<br>route_emitter.HTTPRouteNATSMessagesEmitted<br><br></th></tr>
-        <tr>
-                <th width="25%">Description</th>
-                <td>
-      This KPI is based on the following metrics:
-      <br><br>
-      <ul>
-        <li><code>route_emitter.HTTPRouteNATSMessagesEmitted</code> reports the lifetime number of route registration messages sent by the Route Emitter component. The metric is emitted for each Route Emitter.</li>
-        <li><code>gorouter.registry_message.route-emitter</code> reports the lifetime number of route registration messages received by the Gorouter. The metric is emitted for each Gorouter instance.</li>
-      </ul>
-      Dynamic configuration that enables the Gorouter to route HTTP requests to apps is published by the Route Emitter component colocated on each Diego cell to the NATS clustered message bus.
-      All router instances subscribed to this message bus receive the same configuration. (Router instances within an isolation segment receive configuration only for cells in the same isolation segment.)
-      <br><br>
-      As Gorouters prune app instances from the route when a TTL expires, each Route Emitter periodically publishes the routing configuration for the app instances on the same cell.
-      <br><br>
-      Therefore, the aggregate number of route registration messages published by all the Route Emitters should be equal to the number of messages received by each Gorouter instance.
-                  <br><br>
-                  <strong>Use</strong>: A difference in the rate of change of these metrics is an indication of an issue in the control plane responsible for updating the routers with changes to the routing table.
-			<br><br>
-			Pivotal recommends alerting when the number of messages received per second for a given router instance falls below the sum of messages emitted per second across all Route Emitters.
-			<br><br>
-			If visualizing these metrics on a dashboard, look for increases in the difference between the rate of messages received and sent. If the number of messages received by a Gorouter instance drops below the sum of messages sent by the Route Emitters, this is an indication of a problem in the control plane.
-                 	<br><br>
-                 	<strong>Origin</strong>: Firehose<br>
-                 	<strong>Type</strong>: Counter<br>
-                  <strong>Frequency</strong>: With each event<br>
-		</td>
-        </tr>
-        <tr>
-                <th>Recommended measurement</th>
-                <td>Difference of 5-minute average of the per second deltas for <code>gorouter.registry_message.route-emitter</code> and sum of <code>route_emitter.HTTPRouteNATSMessagesEmitted</code> for all Route Emitters</td>
-        </tr>
-        <tr>
-                <th>Recommended alert thresholds</th>
-                <td><strong>Yellow warning</strong>: Dynamic<br>
-                <strong>Red critical</strong>: Dynamic</td>
-        </tr>
-        <tr>
-                <th>Recommended response</th>
-                <td>
-                    <ol>
-                        <li>Check the Gorouter and Route Emitter logs to see if they are experiencing issues when connecting to NATS.</li>
-                        <li>Check the BOSH logs to see if the NATS, Gorouter, or Route Emitter VMs are failing.</li>
-                        <li>Look broadly at the health of all VMs, particularly Diego-related VMs.</li>
-                        <li>If problems persist, pull the Gorouter and Route Emitter logs and contact Pivotal Support.</li>
-                    </ol>
-                    </td>
-        </tr>
-</table>
-
-
 ## <a id="uaa"></a> UAA Metrics
 
 ### <a id="uaa_throughput"></a> UAA Throughput


### PR DESCRIPTION
talked with pcf-networking team, it's not a KPI anymore since pas 2.4 and above. 

-- from pcf-healthwatch team