### PR TITLE
Add documentation for Slow Consumers in 2.3

### DIFF
--- a/docs-content/key-cap-scaling.html.md.erb
+++ b/docs-content/key-cap-scaling.html.md.erb
@@ -246,6 +246,45 @@ There are two key capacity scaling indicators recommended for Firehose performan
    </tr>
 </table>
 
+## <a id="firehose-consumer"></a> Firehose Consumer Scaling Indicator
+
+Pivotal recommends the following scaling indicator for monitoring the performance of consumers of the Firehose.
+
+### <a id="slow-consumer"></a> Slow Consumer Drops
+
+<table>
+  <tr>
+      <th colspan="2" style="text-align: center;">doppler_proxy.slow_consumer</th>
+  </tr>
+   <tr>
+      <th width="25">Description</th>
+      <td>Within PAS, metrics and logs enter the Firehose for transport and exit out of the platform through a consumer nozzle. If the consuming downstream system fails to keep up with the exiting stream of metrics, the Firehose is forced to close the connection to protect itself from back-pressure. The Firehose increments <code>slow_consumer</code> with each connection that it closes because a consumer could not keep up. 
+       </td>
+   </tr>
+   <tr>
+      <th>Purpose</th>
+      <td>This metric indicates that a Firehose consumer, such as a monitoring tool nozzle, is ingesting Firehose messages too slowly. If this number is anomalous, it may result in the downstream monitoring tool not having all expected data, even though that data was successfully transported through the Firehose.
+        
+   </tr>
+   <tr>
+      <th>Recommended thresholds</th>
+      <td><strong>Scale indicator</strong>: Scale when the rate of Firehose Slow Consumer Drops is anomalous for a given environment.<br>
+   </tr>
+   <tr>
+      <th>How to scale</th>
+      <td>Scale up the number of nozzle instances. The number of nozzle instances should match the number of Traffic Controller instances. You can scale a nozzle using the subscription ID specified when the nozzle connects to the Firehose. If you use the same subscription ID on each nozzle instance, the Firehose evenly distributes data across all instances of the nozzle. For example, if you have two nozzle instances with the same subscription ID, the Firehose sends half of the data to one nozzle instance and half to the other. Similarly, if you have three nozzle instances with the same subscription ID, the Firehose sends one-third of the data to each instance. 
+      </td>
+   </tr>
+   <tr>
+      <th>Additional details</th>
+      <td> <strong>Origin</strong>: Firehose<br>
+           <strong>Type</strong>: Counter<br>
+           <strong>Frequency</strong>: Emitted every 5&nbsp;s<br>
+           <strong>Applies to</strong>: cf:doppler<br>
+      </td>
+   </tr>
+</table>
+
 ## <a id="scalable-syslog"></a> CF Syslog Drain Performance Scaling Indicators
 There are three key capacity scaling indicators recommended for CF Syslog Drain performance. 
 


### PR DESCRIPTION
This existed in PAS 2.3 as well. Copying over the docs from 2.4+